### PR TITLE
Add ContactLabel model & attribs to Contact model

### DIFF
--- a/src/main/java/com/beimin/eveapi/model/shared/Contact.java
+++ b/src/main/java/com/beimin/eveapi/model/shared/Contact.java
@@ -5,6 +5,8 @@ public class Contact {
 	private String contactName;
 	private double standing;
 	private boolean inWatchlist;
+	private int contactTypeID;
+	private int labelMask;
 
 	public void setContactID(int fromID) {
 		this.contactID = fromID;
@@ -37,4 +39,22 @@ public class Contact {
 	public void setInWatchlist(boolean inWatchlist) {
 		this.inWatchlist = inWatchlist;
 	}
+
+	public int getContactTypeID() {
+		return contactTypeID;
+	}
+
+	public void setContactTypeID(int contactTypeID) {
+		this.contactTypeID = contactTypeID;
+	}
+
+	public int getLabelMask() {
+		return labelMask;
+	}
+
+	public void setLabelMask(int labelMask) {
+		this.labelMask = labelMask;
+	}
+
+
 }

--- a/src/main/java/com/beimin/eveapi/model/shared/ContactLabel.java
+++ b/src/main/java/com/beimin/eveapi/model/shared/ContactLabel.java
@@ -1,0 +1,25 @@
+package com.beimin.eveapi.model.shared;
+
+/**
+ *
+ */
+public class ContactLabel {
+    private int labelID;
+    private String name;
+
+    public int getLabelID() {
+        return labelID;
+    }
+
+    public void setLabelID(int labelID) {
+        this.labelID = labelID;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/beimin/eveapi/model/shared/ContactLabelList.java
+++ b/src/main/java/com/beimin/eveapi/model/shared/ContactLabelList.java
@@ -1,0 +1,34 @@
+package com.beimin.eveapi.model.shared;
+
+import java.util.ArrayList;
+
+public class ContactLabelList extends ArrayList<ContactLabel> {
+    private static final long serialVersionUID = 1L;
+    public String name;
+    public String key;
+    public String columns;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getColumns() {
+        return columns;
+    }
+
+    public void setColumns(String columns) {
+        this.columns = columns;
+    }
+}

--- a/src/main/java/com/beimin/eveapi/response/pilot/ContactListResponse.java
+++ b/src/main/java/com/beimin/eveapi/response/pilot/ContactListResponse.java
@@ -1,5 +1,6 @@
 package com.beimin.eveapi.response.pilot;
 
+import com.beimin.eveapi.model.shared.ContactLabelList;
 import com.beimin.eveapi.model.shared.ContactList;
 import com.beimin.eveapi.response.shared.AbstractContactListResponse;
 
@@ -9,4 +10,9 @@ public class ContactListResponse extends AbstractContactListResponse {
 	public ContactList getContactList() {
 		return contactLists.get("contactList");
 	}
+
+	public ContactLabelList getContactLabelList() {
+		return labelLists.get("contactLabels");
+	}
+
 }

--- a/src/main/java/com/beimin/eveapi/response/shared/AbstractContactListResponse.java
+++ b/src/main/java/com/beimin/eveapi/response/shared/AbstractContactListResponse.java
@@ -3,18 +3,26 @@ package com.beimin.eveapi.response.shared;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.beimin.eveapi.model.shared.ContactLabelList;
 import com.beimin.eveapi.model.shared.ContactList;
 import com.beimin.eveapi.response.ApiResponse;
 
 public abstract class AbstractContactListResponse extends ApiResponse {
 	private static final long serialVersionUID = 2L;
 	protected Map<String, ContactList> contactLists = new HashMap<String, ContactList>();
+	protected Map<String, ContactLabelList> labelLists = new HashMap<String, ContactLabelList>();
 
 	public void add(ContactList list) {
 		this.contactLists.put(list.getName(), list);
 	}
+	public void add(ContactLabelList list) {
+		this.labelLists.put(list.getName(), list);
+	}
 
 	public ContactList get(String name) {
 		return this.contactLists.get(name);
+	}
+	public ContactLabelList getLabels(String name) {
+		return this.labelLists.get(name);
 	}
 }

--- a/src/test/java/com/beimin/eveapi/character/contacts/ContactListParserTest.java
+++ b/src/test/java/com/beimin/eveapi/character/contacts/ContactListParserTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.beimin.eveapi.model.shared.ContactLabel;
+import com.beimin.eveapi.model.shared.ContactLabelList;
 import org.junit.Test;
 
 import com.beimin.eveapi.exception.ApiException;
@@ -29,17 +31,26 @@ public class ContactListParserTest extends FullAuthParserTest {
 
 		ContactList contactList = response.getContactList();
 		assertEquals("contactList", contactList.getName());
-		assertEquals(106, contactList.size());
+		assertEquals(108, contactList.size());
 		Contact apiContact = contactList.iterator().next();
 		assertEquals(3008667, apiContact.getContactID());
 		assertEquals("Falian Khivad", apiContact.getContactName());
 		assertEquals(5.0, apiContact.getStanding(), 1E-15);
 		assertFalse(apiContact.isInWatchlist());
+		assertEquals(1374, apiContact.getContactTypeID());
+		assertEquals(1, apiContact.getLabelMask());
 
 		apiContact = contactList.get(contactList.size() - 1);
 		assertEquals(2065725204, apiContact.getContactID());
 		assertEquals("De Boer", apiContact.getContactName());
 		assertEquals(10.0, apiContact.getStanding(), 1E-15);
 		assertTrue(apiContact.isInWatchlist());
+		assertEquals(1376, apiContact.getContactTypeID());
+		assertEquals(0, apiContact.getLabelMask());
+
+		ContactLabelList contactLabelList = response.getContactLabelList();
+		ContactLabel contactLabel = contactLabelList.get(0);
+		assertEquals(1, contactLabel.getLabelID());
+		assertEquals("Explorers", contactLabel.getName());
 	}
 }

--- a/src/test/java/com/beimin/eveapi/corporation/contacts/ContactListParserTest.java
+++ b/src/test/java/com/beimin/eveapi/corporation/contacts/ContactListParserTest.java
@@ -34,6 +34,8 @@ public class ContactListParserTest extends FullAuthParserTest {
 		assertEquals("Alpha Guardians", apiContact.getContactName());
 		assertEquals(10.0, apiContact.getStanding(), 1E-15);
 		assertFalse(apiContact.isInWatchlist());
+		assertEquals(2, apiContact.getContactTypeID());
+		assertEquals(3, apiContact.getLabelMask());
 
 		ContactList allianceContactList = response.getAllianceContactList();
 		assertEquals("allianceContactList", allianceContactList.getName());
@@ -43,5 +45,7 @@ public class ContactListParserTest extends FullAuthParserTest {
 		assertEquals("X-COM", apiContact.getContactName());
 		assertEquals(5.0, apiContact.getStanding(), 1E-15);
 		assertFalse(apiContact.isInWatchlist());
+		assertEquals(16159, apiContact.getContactTypeID());
+		assertEquals(1, apiContact.getLabelMask());
 	}
 }

--- a/src/test/resources/char/ContactList.xml
+++ b/src/test/resources/char/ContactList.xml
@@ -1,115 +1,120 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <eveapi version="2">
-  <currentTime>2010-11-28 20:08:33</currentTime>
+  <currentTime>2015-09-14 01:30:20</currentTime>
   <result>
-    <rowset name="contactList" key="contactID" columns="contactID,contactName,inWatchlist,standing">
-      <row contactID="3008667" contactName="Falian Khivad" inWatchlist="False" standing="5"/>
-      <row contactID="3008734" contactName="Nayeri Shushi" inWatchlist="False" standing="0"/>
-      <row contactID="3009524" contactName="Afdier Couster" inWatchlist="False" standing="0"/>
-      <row contactID="3011115" contactName="Kibayasu Jimmulen" inWatchlist="False" standing="0"/>
-      <row contactID="3012589" contactName="Jodgauren Olmeigar" inWatchlist="False" standing="0"/>
-      <row contactID="3013966" contactName="Thon Eney" inWatchlist="False" standing="0"/>
-      <row contactID="3014240" contactName="Aitakan Reinsdar" inWatchlist="False" standing="0"/>
-      <row contactID="3014820" contactName="Aneng Tzashrah" inWatchlist="False" standing="0"/>
-      <row contactID="3014891" contactName="Nirela Tzara" inWatchlist="False" standing="0"/>
-      <row contactID="3015092" contactName="Arnettylier Eulancke" inWatchlist="False" standing="0"/>
-      <row contactID="3015400" contactName="Mazuere Vyllocoure" inWatchlist="False" standing="0"/>
-      <row contactID="3016598" contactName="Muvila Milkina" inWatchlist="False" standing="0"/>
-      <row contactID="3016599" contactName="Kaurmoras Uesilen" inWatchlist="False" standing="0"/>
-      <row contactID="3016604" contactName="Yarela Ohio" inWatchlist="False" standing="0"/>
-      <row contactID="3017219" contactName="Uunse Matsikka" inWatchlist="False" standing="0"/>
-      <row contactID="3017262" contactName="Tyngidolf Aurtur" inWatchlist="False" standing="0"/>
-      <row contactID="3017293" contactName="Sotah Imya" inWatchlist="False" standing="0"/>
-      <row contactID="3017307" contactName="Ashokon Bofazan" inWatchlist="False" standing="0"/>
-      <row contactID="3017350" contactName="Kalon Andet" inWatchlist="False" standing="0"/>
-      <row contactID="3017372" contactName="Perrukainen Artoja" inWatchlist="False" standing="0"/>
-      <row contactID="3018463" contactName="Aram Ishtan" inWatchlist="False" standing="0"/>
-      <row contactID="3018474" contactName="Sakem Komal" inWatchlist="False" standing="0"/>
-      <row contactID="3018488" contactName="Demi Lazerus" inWatchlist="False" standing="0"/>
-      <row contactID="3018489" contactName="Nikmar Jyran" inWatchlist="False" standing="0"/>
-      <row contactID="3018490" contactName="Taspar Zolankor" inWatchlist="False" standing="0"/>
-      <row contactID="3018677" contactName="Rian Sumana" inWatchlist="False" standing="0"/>
-      <row contactID="3018678" contactName="Geil Ustegokkur" inWatchlist="False" standing="0"/>
-      <row contactID="3018679" contactName="Anuko Hugandur" inWatchlist="False" standing="0"/>
-      <row contactID="3018837" contactName="Alfiker Maliddar" inWatchlist="False" standing="0"/>
-      <row contactID="3018838" contactName="Ansdald Nyragi" inWatchlist="False" standing="0"/>
-      <row contactID="3018839" contactName="Bria Arnkorin" inWatchlist="False" standing="0"/>
-      <row contactID="3018840" contactName="Evuttur Arpen" inWatchlist="False" standing="0"/>
-      <row contactID="3018841" contactName="Firginia Fodelbert" inWatchlist="False" standing="0"/>
-      <row contactID="3018842" contactName="Halvuli Alfiker" inWatchlist="False" standing="0"/>
-      <row contactID="3018843" contactName="Hebrid Mangarik" inWatchlist="False" standing="0"/>
-      <row contactID="3018844" contactName="Herundio Bodweradat" inWatchlist="False" standing="0"/>
-      <row contactID="3018845" contactName="Jomodar Infreger" inWatchlist="False" standing="0"/>
-      <row contactID="3018846" contactName="Meinevedar Austrudelef" inWatchlist="False" standing="0"/>
-      <row contactID="3018847" contactName="Solur Erfar" inWatchlist="False" standing="0"/>
-      <row contactID="3018848" contactName="Vimeini Jomodar" inWatchlist="False" standing="0"/>
-      <row contactID="3018927" contactName="Uba Virserin" inWatchlist="False" standing="0"/>
-      <row contactID="3018932" contactName="Dalofer Mattore" inWatchlist="False" standing="0"/>
-      <row contactID="3019342" contactName="Eurbibad Kird" inWatchlist="False" standing="0"/>
-      <row contactID="3019343" contactName="Stird Odetlef" inWatchlist="False" standing="0"/>
-      <row contactID="3019346" contactName="Arninald Beinarakur" inWatchlist="False" standing="0"/>
-      <row contactID="3019347" contactName="Harbuko Bedgimund" inWatchlist="False" standing="0"/>
-      <row contactID="3019356" contactName="Sister Alitura" inWatchlist="False" standing="0"/>
-      <row contactID="3019402" contactName="Riff Hebian" inWatchlist="False" standing="0"/>
-      <row contactID="3019406" contactName="Kandus Sandar" inWatchlist="False" standing="0"/>
-      <row contactID="3019407" contactName="Aralin Jick" inWatchlist="False" standing="0"/>
-      <row contactID="3019415" contactName="Karde Romu" inWatchlist="False" standing="0"/>
-      <row contactID="3019455" contactName="Wettor Fugen" inWatchlist="False" standing="0"/>
-      <row contactID="3019456" contactName="Bradondar Alfalur" inWatchlist="False" standing="0"/>
-      <row contactID="3019478" contactName="Artgert Ardreas" inWatchlist="False" standing="0"/>
-      <row contactID="3019479" contactName="Sut Bjar" inWatchlist="False" standing="0"/>
-      <row contactID="138725217" contactName="Bloktar" inWatchlist="True" standing="0"/>
-      <row contactID="160810521" contactName="UnIQu3" inWatchlist="True" standing="0"/>
-      <row contactID="182784411" contactName="DarkStar 1" inWatchlist="False" standing="0"/>
-      <row contactID="186578963" contactName="pshepherd" inWatchlist="True" standing="0"/>
-      <row contactID="187357543" contactName="Detenaev Holanu" inWatchlist="True" standing="0"/>
-      <row contactID="206680731" contactName="Overlord Anubis" inWatchlist="True" standing="0"/>
-      <row contactID="482762628" contactName="CEO Pyrex" inWatchlist="True" standing="0"/>
-      <row contactID="498745672" contactName="Irie Alixyar" inWatchlist="True" standing="0"/>
-      <row contactID="499397358" contactName="Dispatch" inWatchlist="True" standing="0"/>
-      <row contactID="534481067" contactName="Marsian" inWatchlist="True" standing="0"/>
-      <row contactID="581630544" contactName="Perduim Oneraria" inWatchlist="True" standing="0"/>
-      <row contactID="582025121" contactName="Erubadriel" inWatchlist="True" standing="0"/>
-      <row contactID="588014499" contactName="Miffy" inWatchlist="True" standing="0"/>
-      <row contactID="612259562" contactName="Impinge" inWatchlist="True" standing="0"/>
-      <row contactID="644935007" contactName="Katie Door" inWatchlist="True" standing="0"/>
-      <row contactID="666656478" contactName="Inservio Letum" inWatchlist="True" standing="0"/>
-      <row contactID="682099525" contactName="Xotannar" inWatchlist="True" standing="10"/>
-      <row contactID="782937789" contactName="Shep88" inWatchlist="True" standing="0"/>
-      <row contactID="785409039" contactName="Esildra" inWatchlist="True" standing="0"/>
-      <row contactID="792458040" contactName="Ta8ula Rasa" inWatchlist="False" standing="10"/>
-      <row contactID="798678925" contactName="Gilbert Drillerson" inWatchlist="True" standing="0"/>
-      <row contactID="813738272" contactName="Arkasius" inWatchlist="True" standing="0"/>
-      <row contactID="817217271" contactName="Moostang" inWatchlist="True" standing="0"/>
-      <row contactID="825180053" contactName="Sutaa" inWatchlist="True" standing="0"/>
-      <row contactID="847198196" contactName="Cal Maestro" inWatchlist="True" standing="0"/>
-      <row contactID="852939468" contactName="Phsynobaby" inWatchlist="True" standing="10"/>
-      <row contactID="885370156" contactName="Maginot" inWatchlist="True" standing="0"/>
-      <row contactID="920407689" contactName="Ad Sales" inWatchlist="True" standing="5"/>
-      <row contactID="937386930" contactName="DonkeyKong" inWatchlist="True" standing="0"/>
-      <row contactID="963288509" contactName="Keiler" inWatchlist="True" standing="0"/>
-      <row contactID="999387023" contactName="Yunlai" inWatchlist="True" standing="0"/>
-      <row contactID="1004356136" contactName="Incub" inWatchlist="True" standing="10"/>
-      <row contactID="1012596743" contactName="Rexy" inWatchlist="True" standing="0"/>
-      <row contactID="1016150715" contactName="Eve Online Hold'Em" inWatchlist="False" standing="0"/>
-      <row contactID="1029841145" contactName="AnaphylacticShock" inWatchlist="True" standing="0"/>
-      <row contactID="1101668488" contactName="Krelo Reich" inWatchlist="True" standing="0"/>
-      <row contactID="1145153045" contactName="David Grogan" inWatchlist="True" standing="10"/>
-      <row contactID="1194179536" contactName="Zer Res" inWatchlist="True" standing="0"/>
-      <row contactID="1203552209" contactName="ShadowFinder" inWatchlist="True" standing="10"/>
-      <row contactID="1484336291" contactName="Dagroru Krulroo" inWatchlist="True" standing="0"/>
-      <row contactID="1513842584" contactName="Borazlak" inWatchlist="True" standing="10"/>
-      <row contactID="1522635141" contactName="Zuper" inWatchlist="True" standing="5"/>
-      <row contactID="1530899873" contactName="Krav Damar" inWatchlist="True" standing="10"/>
-      <row contactID="1629994714" contactName="speedy weedy" inWatchlist="True" standing="0"/>
-      <row contactID="1777969239" contactName="Ahrition" inWatchlist="True" standing="0"/>
-      <row contactID="1865456953" contactName="Ar'tee" inWatchlist="True" standing="0"/>
-      <row contactID="1865471026" contactName="Shau Chen" inWatchlist="True" standing="0"/>
-      <row contactID="1906262612" contactName="Landorcan" inWatchlist="True" standing="0"/>
-      <row contactID="1989750429" contactName="Shanzem" inWatchlist="True" standing="0"/>
-      <row contactID="2059097652" contactName="Marco drack" inWatchlist="True" standing="10"/>
-      <row contactID="2065725204" contactName="De Boer" inWatchlist="True" standing="10"/>
+    <rowset name="contactList" key="contactID" columns="contactID,contactName,standing,contactTypeID,labelMask,inWatchlist">
+      <row contactID="3008667" contactName="Falian Khivad" inWatchlist="False" standing="5" contactTypeID="1374" labelMask="1"/>
+      <row contactID="3008734" contactName="Nayeri Shushi" inWatchlist="False" standing="0" contactTypeID="1386" labelMask="0"/>
+      <row contactID="3009524" contactName="Afdier Couster" inWatchlist="False" standing="0" contactTypeID="1377" labelMask="0"/>
+      <row contactID="3011115" contactName="Kibayasu Jimmulen" inWatchlist="False" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="3012589" contactName="Jodgauren Olmeigar" inWatchlist="False" standing="0" contactTypeID="1379" labelMask="0"/>
+      <row contactID="3013966" contactName="Thon Eney" inWatchlist="False" standing="0" contactTypeID="1384" labelMask="0"/>
+      <row contactID="3014240" contactName="Aitakan Reinsdar" inWatchlist="False" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="3014820" contactName="Aneng Tzashrah" inWatchlist="False" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="3014891" contactName="Nirela Tzara" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="3015092" contactName="Arnettylier Eulancke" inWatchlist="False" standing="0" contactTypeID="1374" labelMask="0"/>
+      <row contactID="3015400" contactName="Mazuere Vyllocoure" inWatchlist="False" standing="0" contactTypeID="1376" labelMask="0"/>
+      <row contactID="3016598" contactName="Muvila Milkina" inWatchlist="False" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="3016599" contactName="Kaurmoras Uesilen" inWatchlist="False" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="3016604" contactName="Yarela Ohio" inWatchlist="False" standing="0" contactTypeID="1375" labelMask="0"/>
+      <row contactID="3017219" contactName="Uunse Matsikka" inWatchlist="False" standing="0" contactTypeID="1386" labelMask="0"/>
+      <row contactID="3017262" contactName="Tyngidolf Aurtur" inWatchlist="False" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="3017293" contactName="Sotah Imya" inWatchlist="False" standing="0" contactTypeID="1376" labelMask="0"/>
+      <row contactID="3017307" contactName="Ashokon Bofazan" inWatchlist="False" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="3017350" contactName="Kalon Andet" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="3017372" contactName="Perrukainen Artoja" inWatchlist="False" standing="0" contactTypeID="1384" labelMask="0"/>
+      <row contactID="3018463" contactName="Aram Ishtan" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="3018474" contactName="Sakem Komal" inWatchlist="False" standing="0" contactTypeID="1379" labelMask="0"/>
+      <row contactID="3018488" contactName="Demi Lazerus" inWatchlist="False" standing="0" contactTypeID="1374" labelMask="0"/>
+      <row contactID="3018489" contactName="Nikmar Jyran" inWatchlist="False" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="3018490" contactName="Taspar Zolankor" inWatchlist="False" standing="0" contactTypeID="1375" labelMask="0"/>
+      <row contactID="3018677" contactName="Rian Sumana" inWatchlist="False" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="3018678" contactName="Geil Ustegokkur" inWatchlist="False" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="3018679" contactName="Anuko Hugandur" inWatchlist="False" standing="0" contactTypeID="1377" labelMask="0"/>
+      <row contactID="3018837" contactName="Alfiker Maliddar" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="3018838" contactName="Ansdald Nyragi" inWatchlist="False" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="3018839" contactName="Bria Arnkorin" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="3018840" contactName="Evuttur Arpen" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="3018841" contactName="Firginia Fodelbert" inWatchlist="False" standing="0" contactTypeID="1374" labelMask="0"/>
+      <row contactID="3018842" contactName="Halvuli Alfiker" inWatchlist="False" standing="0" contactTypeID="1379" labelMask="0"/>
+      <row contactID="3018843" contactName="Hebrid Mangarik" inWatchlist="False" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="3018844" contactName="Herundio Bodweradat" inWatchlist="False" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="3018845" contactName="Jomodar Infreger" inWatchlist="False" standing="0" contactTypeID="1377" labelMask="0"/>
+      <row contactID="3018846" contactName="Meinevedar Austrudelef" inWatchlist="False" standing="0" contactTypeID="1376" labelMask="0"/>
+      <row contactID="3018847" contactName="Solur Erfar" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="3018848" contactName="Vimeini Jomodar" inWatchlist="False" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="3018927" contactName="Uba Virserin" inWatchlist="False" standing="0" contactTypeID="1384" labelMask="0"/>
+      <row contactID="3018932" contactName="Dalofer Mattore" inWatchlist="False" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="3019342" contactName="Eurbibad Kird" inWatchlist="False" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="3019343" contactName="Stird Odetlef" inWatchlist="False" standing="0" contactTypeID="1376" labelMask="0"/>
+      <row contactID="3019346" contactName="Arninald Beinarakur" inWatchlist="False" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="3019347" contactName="Harbuko Bedgimund" inWatchlist="False" standing="0" contactTypeID="1374" labelMask="0"/>
+      <row contactID="3019356" contactName="Sister Alitura" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="3019402" contactName="Riff Hebian" inWatchlist="False" standing="0" contactTypeID="1384" labelMask="0"/>
+      <row contactID="3019406" contactName="Kandus Sandar" inWatchlist="False" standing="0" contactTypeID="1386" labelMask="0"/>
+      <row contactID="3019407" contactName="Aralin Jick" inWatchlist="False" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="3019415" contactName="Karde Romu" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="3019455" contactName="Wettor Fugen" inWatchlist="False" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="3019456" contactName="Bradondar Alfalur" inWatchlist="False" standing="0" contactTypeID="1375" labelMask="0"/>
+      <row contactID="3019478" contactName="Artgert Ardreas" inWatchlist="False" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="3019479" contactName="Sut Bjar" inWatchlist="False" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="138725217" contactName="Bloktar" inWatchlist="True" standing="0" contactTypeID="1384" labelMask="0"/>
+      <row contactID="160810521" contactName="UnIQu3" inWatchlist="True" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="182784411" contactName="DarkStar 1" inWatchlist="False" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="186578963" contactName="pshepherd" inWatchlist="True" standing="0" contactTypeID="1375" labelMask="0"/>
+      <row contactID="187357543" contactName="Detenaev Holanu" inWatchlist="True" standing="0" contactTypeID="1386" labelMask="0"/>
+      <row contactID="206680731" contactName="Overlord Anubis" inWatchlist="True" standing="0" contactTypeID="1379" labelMask="0"/>
+      <row contactID="482762628" contactName="CEO Pyrex" inWatchlist="True" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="498745672" contactName="Irie Alixyar" inWatchlist="True" standing="0" contactTypeID="1374" labelMask="0"/>
+      <row contactID="499397358" contactName="Dispatch" inWatchlist="True" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="534481067" contactName="Marsian" inWatchlist="True" standing="0" contactTypeID="1379" labelMask="0"/>
+      <row contactID="581630544" contactName="Perduim Oneraria" inWatchlist="True" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="582025121" contactName="Erubadriel" inWatchlist="True" standing="0" contactTypeID="1375" labelMask="0"/>
+      <row contactID="588014499" contactName="Miffy" inWatchlist="True" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="906957604" contactName="Hedonistic Imperative" standing="0" contactTypeID="16159" labelMask="0" inWatchlist="False"/>
+      <row contactID="612259562" contactName="Impinge" inWatchlist="True" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="644935007" contactName="Katie Door" inWatchlist="True" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="666656478" contactName="Inservio Letum" inWatchlist="True" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="682099525" contactName="Xotannar" inWatchlist="True" standing="10" contactTypeID="1375" labelMask="0"/>
+      <row contactID="782937789" contactName="Shep88" inWatchlist="True" standing="0" contactTypeID="1376" labelMask="0"/>
+      <row contactID="785409039" contactName="Esildra" inWatchlist="True" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="792458040" contactName="Ta8ula Rasa" inWatchlist="False" standing="10" contactTypeID="1380" labelMask="0"/>
+      <row contactID="798678925" contactName="Gilbert Drillerson" inWatchlist="True" standing="0" contactTypeID="1375" labelMask="0"/>
+      <row contactID="813738272" contactName="Arkasius" inWatchlist="True" standing="0" contactTypeID="1384" labelMask="0"/>
+      <row contactID="817217271" contactName="Moostang" inWatchlist="True" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="825180053" contactName="Sutaa" inWatchlist="True" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="847198196" contactName="Cal Maestro" inWatchlist="True" standing="0" contactTypeID="1375" labelMask="0"/>
+      <row contactID="852939468" contactName="Phsynobaby" inWatchlist="True" standing="10" contactTypeID="1374" labelMask="0"/>
+      <row contactID="885370156" contactName="Maginot" inWatchlist="True" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="920407689" contactName="Ad Sales" inWatchlist="True" standing="5" contactTypeID="2" labelMask="0"/>
+      <row contactID="937386930" contactName="DonkeyKong" inWatchlist="True" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="963288509" contactName="Keiler" inWatchlist="True" standing="0" contactTypeID="1379" labelMask="0"/>
+      <row contactID="999387023" contactName="Yunlai" inWatchlist="True" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="1004356136" contactName="Incub" inWatchlist="True" standing="10" contactTypeID="1376" labelMask="0"/>
+      <row contactID="1012596743" contactName="Rexy" inWatchlist="True" standing="0" contactTypeID="1377" labelMask="0"/>
+      <row contactID="1016150715" contactName="Eve Online Hold'Em" inWatchlist="False" standing="0" contactTypeID="2" labelMask="0"/>
+      <row contactID="1029841145" contactName="AnaphylacticShock" inWatchlist="True" standing="0" contactTypeID="1386" labelMask="0"/>
+      <row contactID="1101668488" contactName="Krelo Reich" inWatchlist="True" standing="0" contactTypeID="1375" labelMask="0"/>
+      <row contactID="1145153045" contactName="David Grogan" inWatchlist="True" standing="10" contactTypeID="1378" labelMask="0"/>
+      <row contactID="1194179536" contactName="Zer Res" inWatchlist="True" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="1203552209" contactName="ShadowFinder" inWatchlist="True" standing="10" contactTypeID="1386" labelMask="0"/>
+      <row contactID="1484336291" contactName="Dagroru Krulroo" inWatchlist="True" standing="0" contactTypeID="1379" labelMask="0"/>
+      <row contactID="1513842584" contactName="Borazlak" inWatchlist="True" standing="10" contactTypeID="1384" labelMask="0"/>
+      <row contactID="1522635141" contactName="Zuper" inWatchlist="True" standing="5" contactTypeID="1386" labelMask="0"/>
+      <row contactID="1530899873" contactName="Krav Damar" inWatchlist="True" standing="10" contactTypeID="1380" labelMask="0"/>
+      <row contactID="1629994714" contactName="speedy weedy" inWatchlist="True" standing="0" contactTypeID="1374" labelMask="0"/>
+      <row contactID="1777969239" contactName="Ahrition" inWatchlist="True" standing="0" contactTypeID="1380" labelMask="0"/>
+      <row contactID="1865456953" contactName="Ar'tee" inWatchlist="True" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="1865471026" contactName="Shau Chen" inWatchlist="True" standing="0" contactTypeID="1373" labelMask="0"/>
+      <row contactID="1906262612" contactName="Landorcan" inWatchlist="True" standing="0" contactTypeID="1383" labelMask="0"/>
+      <row contactID="1989750429" contactName="Shanzem" inWatchlist="True" standing="0" contactTypeID="1378" labelMask="0"/>
+      <row contactID="2059097652" contactName="Marco drack" inWatchlist="True" standing="10" contactTypeID="1386" labelMask="0"/>
+      <row contactID="2007099315" contactName="Dark Shadow Industries" standing="-5" contactTypeID="2" labelMask="0" inWatchlist="False"/>
+      <row contactID="2065725204" contactName="De Boer" inWatchlist="True" standing="10" contactTypeID="1376" labelMask="0"/>
+    </rowset>
+    <rowset name="contactLabels" key="labelID" columns="name">
+      <row labelID="1" name="Explorers"/>
     </rowset>
   </result>
-  <cachedUntil>2010-11-28 20:23:34</cachedUntil>
+  <cachedUntil>2015-09-14 01:45:20</cachedUntil>
 </eveapi>

--- a/src/test/resources/corp/ContactList.xml
+++ b/src/test/resources/corp/ContactList.xml
@@ -1,240 +1,247 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <eveapi version="2">
-  <currentTime>2010-11-28 20:23:15</currentTime>
+  <currentTime>2015-09-14 01:30:20</currentTime>
   <result>
     <rowset name="corporateContactList" key="contactID" columns="contactID,contactName,standing">
-      <row contactID="126118228" contactName="Alpha Guardians" standing="10"/>
-      <row contactID="473619855" contactName="Pitcarin" standing="10"/>
-      <row contactID="531535869" contactName="EvE Finance" standing="10"/>
-      <row contactID="585899923" contactName="Knickerbollockoff" standing="10"/>
-      <row contactID="644405100" contactName="sindergosa" standing="10"/>
-      <row contactID="709533258" contactName="SpoonFed Mouse" standing="10"/>
-      <row contactID="792458040" contactName="Ta8ula Rasa" standing="10"/>
-      <row contactID="866765375" contactName="Monkeys in Space" standing="10"/>
-      <row contactID="964827390" contactName="OreGrabber" standing="10"/>
-      <row contactID="1203552209" contactName="ShadowFinder" standing="10"/>
-      <row contactID="1335928278" contactName="no VAT" standing="10"/>
-      <row contactID="1391420319" contactName="Degothin" standing="5"/>
-      <row contactID="1420461979" contactName="Black Mesa Mavericks" standing="10"/>
-      <row contactID="1479326323" contactName="Capitain Rimmer" standing="10"/>
-      <row contactID="1530899873" contactName="Krav Damar" standing="10"/>
-      <row contactID="1672057596" contactName="Mrs Rimmers" standing="10"/>
-      <row contactID="1801181297" contactName="Santairia" standing="10"/>
-      <row contactID="1980129004" contactName="Gear Stick" standing="10"/>
-      <row contactID="2022575723" contactName="LEGION." standing="10"/>
+      <row contactID="126118228" contactName="Alpha Guardians" standing="10" contactTypeID="2" labelMask="3"/>
+      <row contactID="473619855" contactName="Pitcarin" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="531535869" contactName="EvE Finance" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="585899923" contactName="Knickerbollockoff" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="644405100" contactName="sindergosa" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="709533258" contactName="SpoonFed Mouse" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="792458040" contactName="Ta8ula Rasa" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="866765375" contactName="Monkeys in Space" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="964827390" contactName="OreGrabber" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="1203552209" contactName="ShadowFinder" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="1335928278" contactName="no VAT" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="1391420319" contactName="Degothin" standing="5" contactTypeID="1382" labelMask="0"/>
+      <row contactID="1420461979" contactName="Black Mesa Mavericks" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="1479326323" contactName="Capitain Rimmer" standing="10" contactTypeID="1377" labelMask="0"/>
+      <row contactID="1530899873" contactName="Krav Damar" standing="10" contactTypeID="1383" labelMask="0"/>
+      <row contactID="1672057596" contactName="Mrs Rimmers" standing="10" contactTypeID="1375" labelMask="0"/>
+      <row contactID="1801181297" contactName="Santairia" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="1980129004" contactName="Gear Stick" standing="10" contactTypeID="2" labelMask="0"/>
+      <row contactID="2022575723" contactName="LEGION." standing="10" contactTypeID="2" labelMask="0"/>
+    </rowset>
+    <rowset name="corporateContactLabels" key="labelID" columns="name">
+      <row labelID="1" name="War"/>
+      <row labelID="2" name="Peace"/>
     </rowset>
     <rowset name="allianceContactList" key="contactID" columns="contactID,contactName,standing">
-      <row contactID="121766272" contactName="X-COM" standing="5"/>
-      <row contactID="131511956" contactName="Tactical Narcotics Team" standing="5"/>
-      <row contactID="150097440" contactName="Get Off My Lawn" standing="5"/>
-      <row contactID="157420922" contactName="Rough Necks" standing="-10"/>
-      <row contactID="160174668" contactName="0utbreak" standing="-10"/>
-      <row contactID="166439722" contactName="Tau Ceti Federation" standing="0"/>
-      <row contactID="167433096" contactName="coracao ardente" standing="-5"/>
-      <row contactID="212716751" contactName="Majesta Empire" standing="10"/>
-      <row contactID="220243444" contactName="Genos Occidere" standing="-10"/>
-      <row contactID="225616427" contactName="Teabaggers" standing="-10"/>
-      <row contactID="228932850" contactName="Zenith Affinity" standing="0"/>
-      <row contactID="233278303" contactName="Gam3rs For Lif3" standing="-10"/>
-      <row contactID="239739827" contactName="Aegis Militia" standing="10"/>
-      <row contactID="261982681" contactName="Freaks In The Sheets" standing="5"/>
-      <row contactID="273495145" contactName="" standing="-10"/>
-      <row contactID="278169456" contactName="Forbidden Domain" standing="-10"/>
-      <row contactID="284278305" contactName="Atlas Alliance" standing="-10"/>
-      <row contactID="288377808" contactName="Against ALL Authorities" standing="-10"/>
-      <row contactID="292840783" contactName="" standing="-10"/>
-      <row contactID="304762162" contactName="KrisTeta" standing="5"/>
-      <row contactID="354719028" contactName="" standing="5"/>
-      <row contactID="359381534" contactName="Neutron Advanced Industries" standing="-10"/>
-      <row contactID="359486041" contactName="" standing="-10"/>
-      <row contactID="361107026" contactName="" standing="-10"/>
-      <row contactID="370380903" contactName="Vladimarous" standing="5"/>
-      <row contactID="372018475" contactName="" standing="-10"/>
-      <row contactID="374464406" contactName="Blade." standing="-10"/>
-      <row contactID="382958961" contactName="Cyrus Ildemar" standing="-10"/>
-      <row contactID="386292982" contactName="Pandemic Legion" standing="-10"/>
-      <row contactID="392155885" contactName="" standing="10"/>
-      <row contactID="412368634" contactName="YARRR and CO" standing="-10"/>
-      <row contactID="419732684" contactName="HELLS REJECTS" standing="0"/>
-      <row contactID="425446653" contactName="Dead Reckoning Alliance" standing="-10"/>
-      <row contactID="437847786" contactName="The-Defiant" standing="-10"/>
-      <row contactID="467942520" contactName="Warped Aggression" standing="-10"/>
-      <row contactID="498125261" contactName="Test Alliance Please Ignore" standing="5"/>
-      <row contactID="515150526" contactName="The Compass Reloaded" standing="-10"/>
-      <row contactID="521942065" contactName="Rebellion Alliance" standing="5"/>
-      <row contactID="532507245" contactName="" standing="-5"/>
-      <row contactID="546523850" contactName="DEM0N HUNTERS" standing="5"/>
-      <row contactID="551692893" contactName="HYDRA RELOADED" standing="-10"/>
-      <row contactID="559784179" contactName="Cpt nikku" standing="-10"/>
-      <row contactID="569751089" contactName="The Gentlemen of Low Moral Fibre" standing="-10"/>
-      <row contactID="572951382" contactName="STRAG3S" standing="-10"/>
-      <row contactID="577583162" contactName="Priory of Empire" standing="10"/>
-      <row contactID="583103382" contactName="" standing="-10"/>
-      <row contactID="605845106" contactName="DarkSide." standing="-10"/>
-      <row contactID="606743571" contactName="Deaths Right Hand" standing="-10"/>
-      <row contactID="607212516" contactName="United Front Alliance" standing="5"/>
-      <row contactID="628991027" contactName="Morsus Mihi" standing="10"/>
-      <row contactID="644040121" contactName="Buzz Dura" standing="10"/>
-      <row contactID="648853935" contactName="Zahadume" standing="-10"/>
-      <row contactID="670303846" contactName="Cold Steel Alliance" standing="5"/>
-      <row contactID="673381830" contactName="Intrepid Crossing" standing="-10"/>
-      <row contactID="677736532" contactName="Gatlin penguins" standing="-10"/>
-      <row contactID="678102573" contactName="Digital assassins" standing="-10"/>
-      <row contactID="679584932" contactName="SpaceMonkey's Alliance" standing="5"/>
-      <row contactID="686819242" contactName="Borealis Innovations" standing="10"/>
-      <row contactID="701459600" contactName="Electus Matari" standing="-10"/>
-      <row contactID="702590930" contactName="Oe'hi" standing="-10"/>
-      <row contactID="703129312" contactName="Cry Havoc." standing="-10"/>
-      <row contactID="707612228" contactName="Exit Strategy." standing="5"/>
-      <row contactID="723015129" contactName="OWN Alliance" standing="5"/>
-      <row contactID="728630599" contactName="The Boat Violencing Initiative" standing="-10"/>
-      <row contactID="741557221" contactName="RAZOR Alliance" standing="10"/>
-      <row contactID="743826619" contactName="Legionnaire Services Ltd." standing="5"/>
-      <row contactID="753644383" contactName="Privateer Alliance" standing="-10"/>
-      <row contactID="788930973" contactName="The Exodus Project" standing="-10"/>
-      <row contactID="791571262" contactName="New Justice" standing="-10"/>
-      <row contactID="797297129" contactName="Ascendancy United" standing="10"/>
-      <row contactID="818960303" contactName="Beatus Venator" standing="-10"/>
-      <row contactID="824518128" contactName="GoonSwarm" standing="-10"/>
-      <row contactID="854534413" contactName="Violent Entity" standing="5"/>
-      <row contactID="855555544" contactName="Black Core Alliance" standing="5"/>
-      <row contactID="869740032" contactName="Dust 2 Dust" standing="5"/>
-      <row contactID="873672554" contactName="" standing="-5"/>
-      <row contactID="878776074" contactName="IT Alliance" standing="-10"/>
-      <row contactID="880013768" contactName="Slammer's Republic" standing="0"/>
-      <row contactID="898617242" contactName="Chaos Theory Alliance" standing="-10"/>
-      <row contactID="905861359" contactName="BricK sQuAD." standing="0"/>
-      <row contactID="906457582" contactName="The G0dfathers" standing="5"/>
-      <row contactID="917344903" contactName="Slackers Incorporated" standing="-10"/>
-      <row contactID="922171437" contactName="GOP KOHTOPA" standing="-10"/>
-      <row contactID="924012559" contactName="Elvish Space Terror Brigade" standing="-10"/>
-      <row contactID="924777585" contactName="Primary Stellar Inter-Corp Holdings" standing="10"/>
-      <row contactID="927292903" contactName="Rote Kapelle" standing="-10"/>
-      <row contactID="933731581" contactName="Triumvirate." standing="-10"/>
-      <row contactID="935808947" contactName="Dead Void" standing="10"/>
-      <row contactID="952418311" contactName="Ivan Schnyder" standing="-10"/>
-      <row contactID="954452553" contactName="colonel gayfayce" standing="-10"/>
-      <row contactID="961192363" contactName="Noir. Mercenary Group" standing="-10"/>
-      <row contactID="974455223" contactName="Killer Instinct Industries Inc" standing="-10"/>
-      <row contactID="975528208" contactName="The Fendahlian Collective" standing="5"/>
-      <row contactID="982284363" contactName="Sev3rance" standing="5"/>
-      <row contactID="991389427" contactName="LurkerZ" standing="5"/>
-      <row contactID="991857862" contactName="Dark Region" standing="5"/>
-      <row contactID="999315127" contactName="Voodoo Tribes" standing="5"/>
-      <row contactID="1006628817" contactName="Aeternus." standing="-10"/>
-      <row contactID="1006830534" contactName="Fidelas Constans" standing="10"/>
-      <row contactID="1014468640" contactName="" standing="-10"/>
-      <row contactID="1018389948" contactName="Dreddit" standing="5"/>
-      <row contactID="1045664212" contactName="Legion Of The ShiningStar" standing="10"/>
-      <row contactID="1060992628" contactName="Donkey Punch." standing="-10"/>
-      <row contactID="1082138174" contactName="Nomad LLP" standing="10"/>
-      <row contactID="1136157539" contactName="C0VEN" standing="-10"/>
-      <row contactID="1137908185" contactName="" standing="5"/>
-      <row contactID="1141482267" contactName="Chaos Reborn" standing="-10"/>
-      <row contactID="1146667473" contactName="" standing="5"/>
-      <row contactID="1147488332" contactName="The Kadeshi" standing="-10"/>
-      <row contactID="1161301829" contactName="The DEVIL'S REJECT'S" standing="5"/>
-      <row contactID="1163099440" contactName="Nightscream" standing="-10"/>
-      <row contactID="1169749181" contactName="TaX DoDger" standing="-10"/>
-      <row contactID="1169948630" contactName="Never Enough Ammo" standing="-10"/>
-      <row contactID="1171218469" contactName="" standing="-10"/>
-      <row contactID="1182801433" contactName="On the Rocks" standing="0"/>
-      <row contactID="1193172928" contactName="bwise86" standing="-10"/>
-      <row contactID="1198020766" contactName="C0NVICTED" standing="5"/>
-      <row contactID="1204148554" contactName="Ewoks" standing="-10"/>
-      <row contactID="1207914383" contactName="Assisted Genocide" standing="-10"/>
-      <row contactID="1208650174" contactName="Sodalitas XX" standing="-10"/>
-      <row contactID="1210775195" contactName="Aristocratic Bastards" standing="-10"/>
-      <row contactID="1216945871" contactName="White Noise." standing="-10"/>
-      <row contactID="1220174199" contactName="Fatal Ascension" standing="5"/>
-      <row contactID="1220922756" contactName="Red Alliance" standing="-10"/>
-      <row contactID="1228472388" contactName="RED.OverLord" standing="-10"/>
-      <row contactID="1232975879" contactName="Fusion Fleet" standing="-10"/>
-      <row contactID="1235915896" contactName="Solar Revenue Service" standing="-10"/>
-      <row contactID="1257907499" contactName="Redarmy Special Forces" standing="-10"/>
-      <row contactID="1263833767" contactName="Elite Assualt Squad" standing="10"/>
-      <row contactID="1271973829" contactName="The Final Stand." standing="-10"/>
-      <row contactID="1282059165" contactName="Van Diemen's Demise" standing="-10"/>
-      <row contactID="1301367357" contactName="Mordus Angels" standing="-10"/>
-      <row contactID="1305407762" contactName="Transient Atmospherics" standing="10"/>
-      <row contactID="1314208988" contactName="Polar Splendour" standing="5"/>
-      <row contactID="1343655549" contactName="" standing="5"/>
-      <row contactID="1346279275" contactName="Praetorian Networking Group" standing="5"/>
-      <row contactID="1354830081" contactName="Goonswarm Federation" standing="5"/>
-      <row contactID="1392182840" contactName="" standing="-10"/>
-      <row contactID="1408176736" contactName="sizzlore" standing="-10"/>
-      <row contactID="1411711376" contactName="Legion of xXDEATHXx" standing="-10"/>
-      <row contactID="1421691163" contactName="IUS PRIMAE N0CTIS" standing="-10"/>
-      <row contactID="1438160193" contactName="Ev0ke" standing="-10"/>
-      <row contactID="1439278447" contactName="Paxton Federation" standing="10"/>
-      <row contactID="1443952531" contactName="THE FEW." standing="5"/>
-      <row contactID="1455941207" contactName="Mutineers" standing="-10"/>
-      <row contactID="1478426199" contactName="Plutonix" standing="5"/>
-      <row contactID="1494254776" contactName="Stella Polaris." standing="10"/>
-      <row contactID="1496436353" contactName="TIGER888" standing="10"/>
-      <row contactID="1508316288" contactName="NibbleTek" standing="-10"/>
-      <row contactID="1522788853" contactName="En Garde" standing="-10"/>
-      <row contactID="1522842604" contactName="IMPERIAL LEGI0N" standing="0"/>
-      <row contactID="1529325298" contactName="Tread Alliance" standing="10"/>
-      <row contactID="1531067603" contactName="Fool Mental Junket" standing="-10"/>
-      <row contactID="1547299718" contactName="Controlled Chaos" standing="5"/>
-      <row contactID="1548582972" contactName="Mercenary Coalition" standing="-10"/>
-      <row contactID="1570958397" contactName="Bluewater Industries" standing="10"/>
-      <row contactID="1577922045" contactName="Important Internet Spaceship League" standing="-10"/>
-      <row contactID="1583651328" contactName="Northwind Orbital" standing="10"/>
-      <row contactID="1585858780" contactName="Legiunea ROmana" standing="-10"/>
-      <row contactID="1603281980" contactName="Anarchy." standing="-5"/>
-      <row contactID="1613946799" contactName="Intrepid Explorers" standing="5"/>
-      <row contactID="1615084596" contactName="Ion Heavy Industries" standing="10"/>
-      <row contactID="1625277583" contactName="Cosmic Cimmerians" standing="-10"/>
-      <row contactID="1645363239" contactName="Dirt Nap Squad." standing="-10"/>
-      <row contactID="1646124186" contactName="DOGEZA Busters" standing="-10"/>
-      <row contactID="1649108174" contactName="Legion of The Damned." standing="5"/>
-      <row contactID="1649178705" contactName="Everto Rex Regis" standing="-5"/>
-      <row contactID="1650726986" contactName="Evoke." standing="-10"/>
-      <row contactID="1661366862" contactName="The Naked Peas Group Plc." standing="-10"/>
-      <row contactID="1667318335" contactName="IDLE EMPIRE" standing="-10"/>
-      <row contactID="1671078301" contactName="Cult of War" standing="-10"/>
-      <row contactID="1678486127" contactName="G-Force Enterprises" standing="-10"/>
-      <row contactID="1691647675" contactName="Ishuk-Raata Enforcement Directive" standing="10"/>
-      <row contactID="1695357456" contactName="Circle-Of-Two" standing="-10"/>
-      <row contactID="1698753304" contactName="R.A.G.E" standing="10"/>
-      <row contactID="1717525216" contactName="Systematic-Chaos" standing="-10"/>
-      <row contactID="1727758877" contactName="Northern Coalition." standing="-5"/>
-      <row contactID="1728396456" contactName="Dead Terrorists" standing="-10"/>
-      <row contactID="1733643802" contactName="-Mostly Harmless-" standing="10"/>
-      <row contactID="1737362789" contactName="RaVeN Federation" standing="0"/>
-      <row contactID="1744448379" contactName="Inner Shadow" standing="10"/>
-      <row contactID="1776870349" contactName="Brotherhood of Legion's" standing="10"/>
-      <row contactID="1779785385" contactName="neogod3" standing="-10"/>
-      <row contactID="1793718161" contactName="TransWarp Ventures" standing="10"/>
-      <row contactID="1802176600" contactName="Shadow of xXDEATHXx" standing="-10"/>
-      <row contactID="1805778824" contactName="Guardian Angels Corp 1" standing="-10"/>
-      <row contactID="1819965161" contactName="FireStar Legion" standing="10"/>
-      <row contactID="1830664414" contactName="United Abominations" standing="-10"/>
-      <row contactID="1834673134" contactName="Steel Fleet" standing="-10"/>
-      <row contactID="1850896162" contactName="Majesta Frontier Alliance" standing="5"/>
-      <row contactID="1877101147" contactName="Gentlemen's Club" standing="-10"/>
-      <row contactID="1878184099" contactName="Yarrbear Inc." standing="-10"/>
-      <row contactID="1880773238" contactName="Angel Causalities Demolition Crew" standing="10"/>
-      <row contactID="1888622604" contactName="Prime Orbital Systems" standing="-10"/>
-      <row contactID="1898195179" contactName="OMEGA." standing="-10"/>
-      <row contactID="1899990246" contactName="Wildly Inappropriate." standing="10"/>
-      <row contactID="1900696668" contactName="The Initiative." standing="-10"/>
-      <row contactID="1903500835" contactName="Quasar Generation" standing="10"/>
-      <row contactID="1905250435" contactName="AAA Citizens" standing="-10"/>
-      <row contactID="1912170926" contactName="Veneratio Venator Alliance" standing="0"/>
-      <row contactID="1913014423" contactName="" standing="-10"/>
-      <row contactID="1953602912" contactName="Secret Squirrel Readiness Group" standing="5"/>
-      <row contactID="1957501652" contactName="The Foray Project" standing="-5"/>
-      <row contactID="1958196311" contactName="Arcane Alliance" standing="5"/>
-      <row contactID="1963696385" contactName="UN1CUM" standing="-10"/>
-      <row contactID="1965209336" contactName="R.E.P.O." standing="-10"/>
-      <row contactID="1966049571" contactName="Ushra'Khan" standing="-10"/>
-      <row contactID="1966235613" contactName="Black Star Alliance" standing="-10"/>
-      <row contactID="1988009451" contactName="Curatores Veritatis Alliance" standing="0"/>
-      <row contactID="2030512064" contactName="ACE WRECKING COMPANY" standing="5"/>
+      <row contactID="121766272" contactName="X-COM" standing="5" contactTypeID="16159" labelMask="1"/>
+      <row contactID="131511956" contactName="Tactical Narcotics Team" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="150097440" contactName="Get Off My Lawn" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="157420922" contactName="Rough Necks" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="160174668" contactName="0utbreak" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="166439722" contactName="Tau Ceti Federation" standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="167433096" contactName="coracao ardente" standing="-5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="212716751" contactName="Majesta Empire" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="220243444" contactName="Genos Occidere" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="225616427" contactName="Teabaggers" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="228932850" contactName="Zenith Affinity" standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="233278303" contactName="Gam3rs For Lif3" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="239739827" contactName="Aegis Militia" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="261982681" contactName="Freaks In The Sheets" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="273495145" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="278169456" contactName="Forbidden Domain" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="284278305" contactName="Atlas Alliance" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="288377808" contactName="Against ALL Authorities" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="292840783" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="304762162" contactName="KrisTeta" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="354719028" contactName="" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="359381534" contactName="Neutron Advanced Industries" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="359486041" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="361107026" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="370380903" contactName="Vladimarous" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="372018475" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="374464406" contactName="Blade." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="382958961" contactName="Cyrus Ildemar" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="386292982" contactName="Pandemic Legion" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="392155885" contactName="" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="412368634" contactName="YARRR and CO" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="419732684" contactName="HELLS REJECTS" standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="425446653" contactName="Dead Reckoning Alliance" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="437847786" contactName="The-Defiant" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="467942520" contactName="Warped Aggression" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="498125261" contactName="Test Alliance Please Ignore" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="515150526" contactName="The Compass Reloaded" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="521942065" contactName="Rebellion Alliance" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="532507245" contactName="" standing="-5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="546523850" contactName="DEM0N HUNTERS" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="551692893" contactName="HYDRA RELOADED" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="559784179" contactName="Cpt nikku" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="569751089" contactName="The Gentlemen of Low Moral Fibre" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="572951382" contactName="STRAG3S" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="577583162" contactName="Priory of Empire" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="583103382" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="605845106" contactName="DarkSide." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="606743571" contactName="Deaths Right Hand" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="607212516" contactName="United Front Alliance" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="628991027" contactName="Morsus Mihi" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="644040121" contactName="Buzz Dura" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="648853935" contactName="Zahadume" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="670303846" contactName="Cold Steel Alliance" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="673381830" contactName="Intrepid Crossing" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="677736532" contactName="Gatlin penguins" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="678102573" contactName="Digital assassins" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="679584932" contactName="SpaceMonkey's Alliance" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="686819242" contactName="Borealis Innovations" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="701459600" contactName="Electus Matari" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="702590930" contactName="Oe'hi" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="703129312" contactName="Cry Havoc." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="707612228" contactName="Exit Strategy." standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="723015129" contactName="OWN Alliance" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="728630599" contactName="The Boat Violencing Initiative" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="741557221" contactName="RAZOR Alliance" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="743826619" contactName="Legionnaire Services Ltd." standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="753644383" contactName="Privateer Alliance" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="788930973" contactName="The Exodus Project" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="791571262" contactName="New Justice" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="797297129" contactName="Ascendancy United" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="818960303" contactName="Beatus Venator" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="824518128" contactName="GoonSwarm" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="854534413" contactName="Violent Entity" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="855555544" contactName="Black Core Alliance" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="869740032" contactName="Dust 2 Dust" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="873672554" contactName="" standing="-5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="878776074" contactName="IT Alliance" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="880013768" contactName="Slammer's Republic" standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="898617242" contactName="Chaos Theory Alliance" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="905861359" contactName="BricK sQuAD." standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="906457582" contactName="The G0dfathers" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="917344903" contactName="Slackers Incorporated" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="922171437" contactName="GOP KOHTOPA" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="924012559" contactName="Elvish Space Terror Brigade" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="924777585" contactName="Primary Stellar Inter-Corp Holdings" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="927292903" contactName="Rote Kapelle" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="933731581" contactName="Triumvirate." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="935808947" contactName="Dead Void" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="952418311" contactName="Ivan Schnyder" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="954452553" contactName="colonel gayfayce" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="961192363" contactName="Noir. Mercenary Group" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="974455223" contactName="Killer Instinct Industries Inc" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="975528208" contactName="The Fendahlian Collective" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="982284363" contactName="Sev3rance" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="991389427" contactName="LurkerZ" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="991857862" contactName="Dark Region" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="999315127" contactName="Voodoo Tribes" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1006628817" contactName="Aeternus." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1006830534" contactName="Fidelas Constans" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1014468640" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1018389948" contactName="Dreddit" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1045664212" contactName="Legion Of The ShiningStar" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1060992628" contactName="Donkey Punch." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1082138174" contactName="Nomad LLP" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1136157539" contactName="C0VEN" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1137908185" contactName="" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1141482267" contactName="Chaos Reborn" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1146667473" contactName="" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1147488332" contactName="The Kadeshi" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1161301829" contactName="The DEVIL'S REJECT'S" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1163099440" contactName="Nightscream" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1169749181" contactName="TaX DoDger" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1169948630" contactName="Never Enough Ammo" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1171218469" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1182801433" contactName="On the Rocks" standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1193172928" contactName="bwise86" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1198020766" contactName="C0NVICTED" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1204148554" contactName="Ewoks" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1207914383" contactName="Assisted Genocide" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1208650174" contactName="Sodalitas XX" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1210775195" contactName="Aristocratic Bastards" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1216945871" contactName="White Noise." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1220174199" contactName="Fatal Ascension" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1220922756" contactName="Red Alliance" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1228472388" contactName="RED.OverLord" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1232975879" contactName="Fusion Fleet" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1235915896" contactName="Solar Revenue Service" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1257907499" contactName="Redarmy Special Forces" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1263833767" contactName="Elite Assualt Squad" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1271973829" contactName="The Final Stand." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1282059165" contactName="Van Diemen's Demise" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1301367357" contactName="Mordus Angels" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1305407762" contactName="Transient Atmospherics" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1314208988" contactName="Polar Splendour" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1343655549" contactName="" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1346279275" contactName="Praetorian Networking Group" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1354830081" contactName="Goonswarm Federation" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1392182840" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1408176736" contactName="sizzlore" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1411711376" contactName="Legion of xXDEATHXx" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1421691163" contactName="IUS PRIMAE N0CTIS" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1438160193" contactName="Ev0ke" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1439278447" contactName="Paxton Federation" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1443952531" contactName="THE FEW." standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1455941207" contactName="Mutineers" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1478426199" contactName="Plutonix" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1494254776" contactName="Stella Polaris." standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1496436353" contactName="TIGER888" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1508316288" contactName="NibbleTek" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1522788853" contactName="En Garde" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1522842604" contactName="IMPERIAL LEGI0N" standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1529325298" contactName="Tread Alliance" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1531067603" contactName="Fool Mental Junket" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1547299718" contactName="Controlled Chaos" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1548582972" contactName="Mercenary Coalition" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1570958397" contactName="Bluewater Industries" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1577922045" contactName="Important Internet Spaceship League" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1583651328" contactName="Northwind Orbital" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1585858780" contactName="Legiunea ROmana" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1603281980" contactName="Anarchy." standing="-5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1613946799" contactName="Intrepid Explorers" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1615084596" contactName="Ion Heavy Industries" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1625277583" contactName="Cosmic Cimmerians" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1645363239" contactName="Dirt Nap Squad." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1646124186" contactName="DOGEZA Busters" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1649108174" contactName="Legion of The Damned." standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1649178705" contactName="Everto Rex Regis" standing="-5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1650726986" contactName="Evoke." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1661366862" contactName="The Naked Peas Group Plc." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1667318335" contactName="IDLE EMPIRE" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1671078301" contactName="Cult of War" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1678486127" contactName="G-Force Enterprises" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1691647675" contactName="Ishuk-Raata Enforcement Directive" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1695357456" contactName="Circle-Of-Two" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1698753304" contactName="R.A.G.E" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1717525216" contactName="Systematic-Chaos" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1727758877" contactName="Northern Coalition." standing="-5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1728396456" contactName="Dead Terrorists" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1733643802" contactName="-Mostly Harmless-" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1737362789" contactName="RaVeN Federation" standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1744448379" contactName="Inner Shadow" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1776870349" contactName="Brotherhood of Legion's" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1779785385" contactName="neogod3" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1793718161" contactName="TransWarp Ventures" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1802176600" contactName="Shadow of xXDEATHXx" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1805778824" contactName="Guardian Angels Corp 1" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1819965161" contactName="FireStar Legion" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1830664414" contactName="United Abominations" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1834673134" contactName="Steel Fleet" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1850896162" contactName="Majesta Frontier Alliance" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1877101147" contactName="Gentlemen's Club" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1878184099" contactName="Yarrbear Inc." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1880773238" contactName="Angel Causalities Demolition Crew" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1888622604" contactName="Prime Orbital Systems" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1898195179" contactName="OMEGA." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1899990246" contactName="Wildly Inappropriate." standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1900696668" contactName="The Initiative." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1903500835" contactName="Quasar Generation" standing="10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1905250435" contactName="AAA Citizens" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1912170926" contactName="Veneratio Venator Alliance" standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1913014423" contactName="" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1953602912" contactName="Secret Squirrel Readiness Group" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1957501652" contactName="The Foray Project" standing="-5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1958196311" contactName="Arcane Alliance" standing="5" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1963696385" contactName="UN1CUM" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1965209336" contactName="R.E.P.O." standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1966049571" contactName="Ushra'Khan" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1966235613" contactName="Black Star Alliance" standing="-10" contactTypeID="16159" labelMask="0"/>
+      <row contactID="1988009451" contactName="Curatores Veritatis Alliance" standing="0" contactTypeID="16159" labelMask="0"/>
+      <row contactID="2030512064" contactName="ACE WRECKING COMPANY" standing="5" contactTypeID="16159" labelMask="0"/>
+    </rowset>
+    <rowset name="allianceContactLabels" key="labelID" columns="name">
+      <row labelID="1" name="Gamers"/>
     </rowset>
   </result>
-  <cachedUntil>2010-11-28 20:38:15</cachedUntil>
+  <cachedUntil>2015-09-14 01:45:20</cachedUntil>
 </eveapi>


### PR DESCRIPTION
ContactLabel is available to be parsed in responses for personal,
corporate, and alliance contacts. A model object is added to capture
this data and exposed through the ContactListParser.

Simiarly two attributes which were available in all contacts have
been added to the model and the values parsed from the APIresponse.

Fixes: #52
Fixes: #53