### PR TITLE
Remove default constructor of AbstractContentHandler to close #112

### DIFF
--- a/src/main/java/com/beimin/eveapi/handler/AbstractContentHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/AbstractContentHandler.java
@@ -45,10 +45,6 @@ public abstract class AbstractContentHandler<E extends ApiResponse> extends Defa
     private final StringBuilder accumulator = new StringBuilder();
     private ApiError error;
 
-    public AbstractContentHandler() {
-        this(null);
-    }
-
     public AbstractContentHandler(final E response) {
         super();
         this.response = response;
@@ -268,10 +264,6 @@ public abstract class AbstractContentHandler<E extends ApiResponse> extends Defa
         for (String s : add) {
             set.add(s.toLowerCase(Locale.ENGLISH));
         }
-    }
-
-    protected void setResponse(final E response) {
-        this.response = response;
     }
 
     public E getResponse() {

--- a/src/main/java/com/beimin/eveapi/handler/AbstractContentListHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/AbstractContentListHandler.java
@@ -1,30 +1,15 @@
 package com.beimin.eveapi.handler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
 import com.beimin.eveapi.response.ApiListResponse;
 
 public abstract class AbstractContentListHandler<E extends ApiListResponse<B>, B> extends AbstractContentHandler<E> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractContentListHandler.class);
-
-    private final Class<E> clazz;
     private B item;
 
-    public AbstractContentListHandler(final Class<E> clazz) {
-        super();
-        this.clazz = clazz;
-    }
-
-    @Override
-    public void startDocument() throws SAXException {
-        try {
-            setResponse(clazz.newInstance());
-        } catch (final InstantiationException | IllegalAccessException e) {
-            LOGGER.error("Could't start document", e);
-        }
+    public AbstractContentListHandler(E response) {
+        super(response);
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/ServerStatusHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/ServerStatusHandler.java
@@ -5,9 +5,8 @@ import org.xml.sax.SAXException;
 import com.beimin.eveapi.response.ServerStatusResponse;
 
 public class ServerStatusHandler extends AbstractContentHandler<ServerStatusResponse> {
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new ServerStatusResponse());
+    public ServerStatusHandler() {
+        super(new ServerStatusResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/account/AccountStatusHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/account/AccountStatusHandler.java
@@ -12,9 +12,8 @@ public class AccountStatusHandler extends AbstractContentHandler<AccountStatusRe
     private AccountStatus accountStatus;
     private String rowsetName;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new AccountStatusResponse());
+    public AccountStatusHandler() {
+        super(new AccountStatusResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/account/ApiKeyInfoHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/account/ApiKeyInfoHandler.java
@@ -14,9 +14,8 @@ import com.beimin.eveapi.response.account.ApiKeyInfoResponse;
 public class ApiKeyInfoHandler extends AbstractContentHandler<ApiKeyInfoResponse> {
     private ApiKeyInfo apiKeyInfo;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new ApiKeyInfoResponse());
+    public ApiKeyInfoHandler() {
+        super(new ApiKeyInfoResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/account/CharactersHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/account/CharactersHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.account.CharactersResponse;
 
 public class CharactersHandler extends AbstractContentListHandler<CharactersResponse, Character> {
     public CharactersHandler() {
-        super(CharactersResponse.class);
+        super(new CharactersResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/calllist/CallListHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/calllist/CallListHandler.java
@@ -17,9 +17,8 @@ public class CallListHandler extends AbstractContentHandler<CallListResponse> {
     private boolean calls;
     private CallList callList;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new CallListResponse());
+    public CallListHandler() {
+        super(new CallListResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/CalendarEventAttendeesHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/CalendarEventAttendeesHandler.java
@@ -11,7 +11,7 @@ import com.beimin.eveapi.response.character.CalendarEventResponse;
 
 public class CalendarEventAttendeesHandler extends AbstractContentListHandler<CalendarEventAttendeesResponse, CalendarEventAttendee> {
     public CalendarEventAttendeesHandler() {
-        super(CalendarEventAttendeesResponse.class);
+        super(new CalendarEventAttendeesResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/CharacterSheetHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/CharacterSheetHandler.java
@@ -23,9 +23,8 @@ public class CharacterSheetHandler extends AbstractContentHandler<CharacterSheet
     private static final String ATTRIBUTE_ROLE_ID = "roleID";
     private String rowsetName;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new CharacterSheetResponse());
+    public CharacterSheetHandler() {
+        super(new CharacterSheetResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/ChatChannelsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/ChatChannelsHandler.java
@@ -17,9 +17,8 @@ public class ChatChannelsHandler extends AbstractContentHandler<ChatChannelsResp
     private ChatChannel current;
     private String pos;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new ChatChannelsResponse());
+    public ChatChannelsHandler() {
+        super(new ChatChannelsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/ContactNotificationsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/ContactNotificationsHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.character.ContactNotificationsResponse;
 public class ContactNotificationsHandler extends AbstractContentListHandler<ContactNotificationsResponse, ContactNotification> {
 
     public ContactNotificationsHandler() {
-        super(ContactNotificationsResponse.class);
+        super(new ContactNotificationsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/MailBodiesHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/MailBodiesHandler.java
@@ -10,7 +10,7 @@ import com.beimin.eveapi.response.character.MailBodiesResponse;
 public class MailBodiesHandler extends AbstractContentListHandler<MailBodiesResponse, MailBody> {
 
     public MailBodiesHandler() {
-        super(MailBodiesResponse.class);
+        super(new MailBodiesResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/MailMessagesHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/MailMessagesHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.character.MailMessagesResponse;
 public class MailMessagesHandler extends AbstractContentListHandler<MailMessagesResponse, MailMessage> {
 
     public MailMessagesHandler() {
-        super(MailMessagesResponse.class);
+        super(new MailMessagesResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/MailingListsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/MailingListsHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.character.MailingListsResponse;
 public class MailingListsHandler extends AbstractContentListHandler<MailingListsResponse, MailingList> {
 
     public MailingListsHandler() {
-        super(MailingListsResponse.class);
+        super(new MailingListsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/MedalsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/MedalsHandler.java
@@ -11,7 +11,7 @@ public class MedalsHandler extends AbstractContentListHandler<MedalsResponse, Me
     private String rowsetName;
 
     public MedalsHandler() {
-        super(MedalsResponse.class);
+        super(new MedalsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/NotificationTextsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/NotificationTextsHandler.java
@@ -10,7 +10,7 @@ import com.beimin.eveapi.response.character.NotificationTextsResponse;
 public class NotificationTextsHandler extends AbstractContentListHandler<NotificationTextsResponse, NotificationText> {
 
     public NotificationTextsHandler() {
-        super(NotificationTextsResponse.class);
+        super(new NotificationTextsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/NotificationsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/NotificationsHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.character.NotificationsResponse;
 public class NotificationsHandler extends AbstractContentListHandler<NotificationsResponse, Notification> {
 
     public NotificationsHandler() {
-        super(NotificationsResponse.class);
+        super(new NotificationsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/ResearchHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/ResearchHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.character.ResearchResponse;
 
 public class ResearchHandler extends AbstractContentListHandler<ResearchResponse, ResearchAgent> {
     public ResearchHandler() {
-        super(ResearchResponse.class);
+        super(new ResearchResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/SkillInTrainingHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/SkillInTrainingHandler.java
@@ -6,9 +6,8 @@ import com.beimin.eveapi.handler.AbstractContentHandler;
 import com.beimin.eveapi.response.character.SkillInTrainingResponse;
 
 public class SkillInTrainingHandler extends AbstractContentHandler<SkillInTrainingResponse> {
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new SkillInTrainingResponse());
+    public SkillInTrainingHandler() {
+        super(new SkillInTrainingResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/SkillQueueHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/SkillQueueHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.character.SkillQueueResponse;
 public class SkillQueueHandler extends AbstractContentListHandler<SkillQueueResponse, SkillQueueItem> {
 
     public SkillQueueHandler() {
-        super(SkillQueueResponse.class);
+        super(new SkillQueueResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/character/UpcomingCalendarEventsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/character/UpcomingCalendarEventsHandler.java
@@ -12,7 +12,7 @@ import com.beimin.eveapi.response.character.UpcomingCalendarEventsResponse;
 public class UpcomingCalendarEventsHandler extends AbstractContentListHandler<UpcomingCalendarEventsResponse, UpcomingCalendarEvent> {
 
     public UpcomingCalendarEventsHandler() {
-        super(UpcomingCalendarEventsResponse.class);
+        super(new UpcomingCalendarEventsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/ContainerLogHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/ContainerLogHandler.java
@@ -11,7 +11,7 @@ import com.beimin.eveapi.response.corporation.ContainerLogResponse;
 
 public class ContainerLogHandler extends AbstractContentListHandler<ContainerLogResponse, ContainerLog> {
     public ContainerLogHandler() {
-        super(ContainerLogResponse.class);
+        super(new ContainerLogResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/CorpSheetHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/CorpSheetHandler.java
@@ -13,9 +13,8 @@ public class CorpSheetHandler extends AbstractContentHandler<CorpSheetResponse> 
     private boolean divisions;
     private boolean walletDivisions;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new CorpSheetResponse());
+    public CorpSheetHandler() {
+        super(new CorpSheetResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/MedalsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/MedalsHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.corporation.MedalsResponse;
 
 public class MedalsHandler extends AbstractContentListHandler<MedalsResponse, Medal> {
     public MedalsHandler() {
-        super(MedalsResponse.class);
+        super(new MedalsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/MemberMedalsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/MemberMedalsHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.corporation.MemberMedalsResponse;
 public class MemberMedalsHandler extends AbstractContentListHandler<MemberMedalsResponse, MemberMedal> {
 
     public MemberMedalsHandler() {
-        super(MemberMedalsResponse.class);
+        super(new MemberMedalsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/MemberSecurityHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/MemberSecurityHandler.java
@@ -10,13 +10,12 @@ import com.beimin.eveapi.response.ApiResponse;
 import com.beimin.eveapi.response.corporation.MemberSecurityResponse;
 
 public class MemberSecurityHandler extends AbstractContentHandler<MemberSecurityResponse> {
-    private final RolesHandler<ApiResponse> roleHandler = new RolesHandler<>();
+    private final RolesHandler<ApiResponse> roleHandler = new RolesHandler<>(new ApiResponse());
     private boolean titles;
     private SecurityMember member;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new MemberSecurityResponse());
+    public MemberSecurityHandler() {
+        super(new MemberSecurityResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/MemberSecurityLogHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/MemberSecurityLogHandler.java
@@ -14,7 +14,7 @@ public class MemberSecurityLogHandler extends AbstractContentListHandler<MemberS
     private RoleHistory roleHistory;
 
     public MemberSecurityLogHandler() {
-        super(MemberSecurityLogResponse.class);
+        super(new MemberSecurityLogResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/MemberTrackingHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/MemberTrackingHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.corporation.MemberTrackingResponse;
 public class MemberTrackingHandler extends AbstractContentListHandler<MemberTrackingResponse, Member> {
 
     public MemberTrackingHandler() {
-        super(MemberTrackingResponse.class);
+        super(new MemberTrackingResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/OutpostListHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/OutpostListHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.corporation.OutpostListResponse;
 public class OutpostListHandler extends AbstractContentListHandler<OutpostListResponse, Outpost> {
 
     public OutpostListHandler() {
-        super(OutpostListResponse.class);
+        super(new OutpostListResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/OutpostServiceDetailHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/OutpostServiceDetailHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.corporation.OutpostServiceDetailResponse;
 
 public class OutpostServiceDetailHandler extends AbstractContentListHandler<OutpostServiceDetailResponse, OutpostServiceDetail> {
     public OutpostServiceDetailHandler() {
-        super(OutpostServiceDetailResponse.class);
+        super(new OutpostServiceDetailResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/RolesHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/RolesHandler.java
@@ -9,6 +9,10 @@ import com.beimin.eveapi.model.corporation.TitleWithRoles;
 import com.beimin.eveapi.response.ApiResponse;
 
 public class RolesHandler<E extends ApiResponse> extends AbstractContentHandler<E> {
+    public RolesHandler(E response) {
+        super(response);
+    }
+
     private boolean roles;
     private boolean grantableRoles;
     private boolean rolesAtHQ;

--- a/src/main/java/com/beimin/eveapi/handler/corporation/ShareholdersHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/ShareholdersHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.corporation.ShareholdersResponse;
 
 public class ShareholdersHandler extends AbstractContentListHandler<ShareholdersResponse, Shareholder> {
     public ShareholdersHandler() {
-        super(ShareholdersResponse.class);
+        super(new ShareholdersResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/StarbaseDetailHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/StarbaseDetailHandler.java
@@ -8,9 +8,8 @@ import com.beimin.eveapi.model.corporation.CombatSetting;
 import com.beimin.eveapi.response.corporation.StarbaseDetailResponse;
 
 public class StarbaseDetailHandler extends AbstractContentHandler<StarbaseDetailResponse> {
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new StarbaseDetailResponse());
+    public StarbaseDetailHandler() {
+        super(new StarbaseDetailResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/StarbaseListHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/StarbaseListHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.corporation.StarbaseListResponse;
 public class StarbaseListHandler extends AbstractContentListHandler<StarbaseListResponse, Starbase> {
 
     public StarbaseListHandler() {
-        super(StarbaseListResponse.class);
+        super(new StarbaseListResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/corporation/TitlesHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/corporation/TitlesHandler.java
@@ -9,11 +9,11 @@ import com.beimin.eveapi.response.ApiResponse;
 import com.beimin.eveapi.response.corporation.TitlesResponse;
 
 public class TitlesHandler extends AbstractContentListHandler<TitlesResponse, TitleWithRoles> {
-    private final RolesHandler<ApiResponse> roleHandler = new RolesHandler<>();
+    private final RolesHandler<ApiResponse> roleHandler = new RolesHandler<>(new ApiResponse());
     private TitleWithRoles title;
 
     public TitlesHandler() {
-        super(TitlesResponse.class);
+        super(new TitlesResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/AllianceListHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/AllianceListHandler.java
@@ -13,7 +13,7 @@ public class AllianceListHandler extends AbstractContentListHandler<AllianceList
     private Alliance alliance;
 
     public AllianceListHandler() {
-        super(AllianceListResponse.class);
+        super(new AllianceListResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/CharacterAffiliationHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/CharacterAffiliationHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.eve.CharacterAffiliationResponse;
 public class CharacterAffiliationHandler extends AbstractContentListHandler<CharacterAffiliationResponse, CharacterAffiliation> {
 
     public CharacterAffiliationHandler() {
-        super(CharacterAffiliationResponse.class);
+        super(new CharacterAffiliationResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/CharacterInfoHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/CharacterInfoHandler.java
@@ -15,9 +15,8 @@ import com.beimin.eveapi.response.eve.CharacterInfoResponse;
 public class CharacterInfoHandler extends AbstractContentHandler<CharacterInfoResponse> {
     private static final String REPLACE_REGEX = "[-\\s]";
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new CharacterInfoResponse());
+    public CharacterInfoHandler() {
+        super(new CharacterInfoResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/CharacterLookupHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/CharacterLookupHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.eve.CharacterLookupResponse;
 public class CharacterLookupHandler extends AbstractContentListHandler<CharacterLookupResponse, CharacterLookup> {
 
     public CharacterLookupHandler() {
-        super(CharacterLookupResponse.class);
+        super(new CharacterLookupResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/ConquerableStationListHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/ConquerableStationListHandler.java
@@ -8,9 +8,8 @@ import com.beimin.eveapi.model.eve.Station;
 import com.beimin.eveapi.response.eve.StationListResponse;
 
 public class ConquerableStationListHandler extends AbstractContentHandler<StationListResponse> {
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new StationListResponse());
+    public ConquerableStationListHandler() {
+        super(new StationListResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/ErrorListHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/ErrorListHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.eve.ErrorListResponse;
 
 public class ErrorListHandler extends AbstractContentListHandler<ErrorListResponse, ErrorListItem> {
     public ErrorListHandler() {
-        super(ErrorListResponse.class);
+        super(new ErrorListResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/FacWarStatsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/FacWarStatsHandler.java
@@ -12,9 +12,8 @@ public class FacWarStatsHandler extends AbstractContentHandler<FacWarStatsRespon
     private boolean factions;
     private boolean factionWars;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new FacWarStatsResponse());
+    public FacWarStatsHandler() {
+        super(new FacWarStatsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/FacWarTopStatsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/FacWarTopStatsHandler.java
@@ -28,9 +28,8 @@ public class FacWarTopStatsHandler extends AbstractContentHandler<FacWarTopStats
     private boolean victoryPointsLastWeek;
     private boolean victoryPointsTotal;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new FacWarTopStatsResponse());
+    public FacWarTopStatsHandler() {
+        super(new FacWarTopStatsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/RefTypesHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/RefTypesHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.eve.RefTypesResponse;
 public class RefTypesHandler extends AbstractContentListHandler<RefTypesResponse, RefType> {
 
     public RefTypesHandler() {
-        super(RefTypesResponse.class);
+        super(new RefTypesResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/SkillTreeHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/SkillTreeHandler.java
@@ -21,7 +21,7 @@ public class SkillTreeHandler extends AbstractContentListHandler<SkillTreeRespon
     private Skill skill;
 
     public SkillTreeHandler() {
-        super(SkillTreeResponse.class);
+        super(new SkillTreeResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/eve/TypeNameHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/eve/TypeNameHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.eve.TypeNameResponse;
 public class TypeNameHandler extends AbstractContentListHandler<TypeNameResponse, EveTypeName> {
 
     public TypeNameHandler() {
-        super(TypeNameResponse.class);
+        super(new TypeNameResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/map/FacWarSystemsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/map/FacWarSystemsHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.map.FacWarSystemsResponse;
 
 public class FacWarSystemsHandler extends AbstractContentListHandler<FacWarSystemsResponse, FacWarSystem> {
     public FacWarSystemsHandler() {
-        super(FacWarSystemsResponse.class);
+        super(new FacWarSystemsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/map/JumpsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/map/JumpsHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.map.JumpsResponse;
 
 public class JumpsHandler extends AbstractContentListHandler<JumpsResponse, SystemJumps> {
     public JumpsHandler() {
-        super(JumpsResponse.class);
+        super(new JumpsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/map/KillsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/map/KillsHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.map.KillsResponse;
 
 public class KillsHandler extends AbstractContentListHandler<KillsResponse, SystemKills> {
     public KillsHandler() {
-        super(KillsResponse.class);
+        super(new KillsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/map/SovereigntyHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/map/SovereigntyHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.map.SovereigntyResponse;
 
 public class SovereigntyHandler extends AbstractContentListHandler<SovereigntyResponse, SystemSovereignty> {
     public SovereigntyHandler() {
-        super(SovereigntyResponse.class);
+        super(new SovereigntyResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/AccountBalanceHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/AccountBalanceHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.shared.AccountBalanceResponse;
 public class AccountBalanceHandler extends AbstractContentListHandler<AccountBalanceResponse, AccountBalance> {
 
     public AccountBalanceHandler() {
-        super(AccountBalanceResponse.class);
+        super(new AccountBalanceResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/AssetListHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/AssetListHandler.java
@@ -13,9 +13,8 @@ public class AssetListHandler extends AbstractContentHandler<AssetListResponse> 
     private Asset currentAsset;
     private final Stack<Asset> stack = new Stack<Asset>();
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new AssetListResponse());
+    public AssetListHandler() {
+        super(new AssetListResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/BlueprintsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/BlueprintsHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.shared.BlueprintsResponse;
 public class BlueprintsHandler extends AbstractContentListHandler<BlueprintsResponse, Blueprint> {
 
     public BlueprintsHandler() {
-        super(BlueprintsResponse.class);
+        super(new BlueprintsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/ContactListHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/ContactListHandler.java
@@ -1,7 +1,5 @@
 package com.beimin.eveapi.handler.shared;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
@@ -13,24 +11,10 @@ import com.beimin.eveapi.response.shared.AbstractContactListResponse;
 public class ContactListHandler<CLR extends AbstractContactListResponse> extends AbstractContentHandler<CLR> {
     private static final String ATTRIBUTE_CONTACT_ID = "contactID";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ContactListHandler.class);
-
-    private final Class<CLR> clazz;
     private String rowsetName;
 
-    public ContactListHandler(final Class<CLR> clazz) {
-        this.clazz = clazz;
-    }
-
-    @Override
-    public void startDocument() throws SAXException {
-        try {
-            setResponse(clazz.newInstance());
-        } catch (final InstantiationException e) {
-            LOGGER.error("Couldn't start document", e);
-        } catch (final IllegalAccessException e) {
-            LOGGER.error("Couldn't start document", e);
-        }
+    public ContactListHandler(final CLR clr) {
+        super(clr);
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/ContractIBidsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/ContractIBidsHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.shared.ContractBidsResponse;
 
 public class ContractIBidsHandler extends AbstractContentListHandler<ContractBidsResponse, ContractBid> {
     public ContractIBidsHandler() {
-        super(ContractBidsResponse.class);
+        super(new ContractBidsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/ContractItemsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/ContractItemsHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.shared.ContractItemsResponse;
 
 public class ContractItemsHandler extends AbstractContentListHandler<ContractItemsResponse, ContractItem> {
     public ContractItemsHandler() {
-        super(ContractItemsResponse.class);
+        super(new ContractItemsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/ContractsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/ContractsHandler.java
@@ -13,7 +13,7 @@ import com.beimin.eveapi.response.shared.ContractsResponse;
 
 public class ContractsHandler extends AbstractContentListHandler<ContractsResponse, Contract> {
     public ContractsHandler() {
-        super(ContractsResponse.class);
+        super(new ContractsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/FacWarStatsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/FacWarStatsHandler.java
@@ -6,9 +6,8 @@ import com.beimin.eveapi.handler.AbstractContentHandler;
 import com.beimin.eveapi.response.shared.FacWarStatsResponse;
 
 public class FacWarStatsHandler extends AbstractContentHandler<FacWarStatsResponse> {
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new FacWarStatsResponse());
+    public FacWarStatsHandler() {
+        super(new FacWarStatsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/IndustryJobsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/IndustryJobsHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.shared.IndustryJobsResponse;
 public class IndustryJobsHandler extends AbstractContentListHandler<IndustryJobsResponse, IndustryJob> {
 
     public IndustryJobsHandler() {
-        super(IndustryJobsResponse.class);
+        super(new IndustryJobsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/KillMailHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/KillMailHandler.java
@@ -16,7 +16,7 @@ public class KillMailHandler extends AbstractContentListHandler<KillMailResponse
     private boolean inItems;
 
     public KillMailHandler() {
-        super(KillMailResponse.class);
+        super(new KillMailResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/LocationsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/LocationsHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.shared.LocationsResponse;
 public class LocationsHandler extends AbstractContentListHandler<LocationsResponse, Location> {
 
     public LocationsHandler() {
-        super(LocationsResponse.class);
+        super(new LocationsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/MarketOrdersHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/MarketOrdersHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.shared.MarketOrdersResponse;
 public class MarketOrdersHandler extends AbstractContentListHandler<MarketOrdersResponse, MarketOrder> {
 
     public MarketOrdersHandler() {
-        super(MarketOrdersResponse.class);
+        super(new MarketOrdersResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/StandingsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/StandingsHandler.java
@@ -11,9 +11,8 @@ import com.beimin.eveapi.response.shared.StandingsResponse;
 public class StandingsHandler extends AbstractContentHandler<StandingsResponse> {
     private NamedList<Standing> list;
 
-    @Override
-    public void startDocument() throws SAXException {
-        setResponse(new StandingsResponse());
+    public StandingsHandler() {
+        super(new StandingsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/WalletJournalHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/WalletJournalHandler.java
@@ -8,7 +8,7 @@ import com.beimin.eveapi.response.shared.WalletJournalResponse;
 
 public class WalletJournalHandler extends AbstractContentListHandler<WalletJournalResponse, JournalEntry> {
     public WalletJournalHandler() {
-        super(WalletJournalResponse.class);
+        super(new WalletJournalResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/handler/shared/WalletTransactionsHandler.java
+++ b/src/main/java/com/beimin/eveapi/handler/shared/WalletTransactionsHandler.java
@@ -9,7 +9,7 @@ import com.beimin.eveapi.response.shared.WalletTransactionsResponse;
 public class WalletTransactionsHandler extends AbstractContentListHandler<WalletTransactionsResponse, WalletTransaction> {
 
     public WalletTransactionsHandler() {
-        super(WalletTransactionsResponse.class);
+        super(new WalletTransactionsResponse());
     }
 
     @Override

--- a/src/main/java/com/beimin/eveapi/parser/shared/AbstractContactListParser.java
+++ b/src/main/java/com/beimin/eveapi/parser/shared/AbstractContactListParser.java
@@ -1,5 +1,8 @@
 package com.beimin.eveapi.parser.shared;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.beimin.eveapi.exception.ApiException;
 import com.beimin.eveapi.handler.AbstractContentHandler;
 import com.beimin.eveapi.handler.shared.ContactListHandler;
@@ -9,13 +12,20 @@ import com.beimin.eveapi.parser.ApiPath;
 import com.beimin.eveapi.response.shared.AbstractContactListResponse;
 
 public abstract class AbstractContactListParser<CLR extends AbstractContactListResponse> extends AbstractApiParser<CLR> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractContactListParser.class);
+
     protected AbstractContactListParser(final Class<CLR> responseClass, final ApiPath path) {
         super(responseClass, 2, path, ApiPage.CONTACT_LIST);
     }
 
     @Override
     protected AbstractContentHandler<CLR> getContentHandler() {
-        return new ContactListHandler<CLR>(clazz);
+        try {
+            return new ContactListHandler<CLR>(clazz.newInstance());
+        } catch (InstantiationException | IllegalAccessException e) {
+            LOGGER.error("Couldn't create response", e);
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
That change makes the code a bit clearer, but adds one ugly instantiation in AbstractContactListParser.